### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.1](https://github.com/graysonarts/jdexmd/compare/v0.1.0...v0.1.1) - 2024-09-29
+
+### Other
+
+- Add a changlog file

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jdexmd"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "color-eyre",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jdexmd"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 repository = "https://github.com/graysonarts/jdexmd"
 description = "A tool to generate a Johnny Decimal system for Obsidian and your Documents folder."


### PR DESCRIPTION
## 🤖 New release
* `jdexmd`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/graysonarts/jdexmd/compare/v0.1.0...v0.1.1) - 2024-09-29

### Other

- Add a changlog file
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).