### PR TITLE
The area markdown template didn't pass in full Id to the id

### DIFF
--- a/example.garden.toml
+++ b/example.garden.toml
@@ -81,7 +81,7 @@ config = """
 # This is the format that the jdex is created using. It is a handlebars template that is used to create the markdown or
 # whatever format you'd like. This is the default format.
 system = "# JDEX {{name}}"
-area = "## {{full_id id}}.{{start id_range}}-{{end id_range}} {{topic}}"
+area = "## {{full_id id}} {{topic}}"
 category = "- {{full_id id}} {{topic}}"
 folder = "  - {{#if (is_folder kind)}}{{full_id id}} {{topic}}{{else}}[[{{full_id id}} {{topic}}]]{{/if}}"
 xfolder = "    - {{#if (is_folder kind)}}{{full_id id}} {{topic}}{{else}}[[{{full_id id}} {{topic}}]]{{/if}}"

--- a/src/markdown.rs
+++ b/src/markdown.rs
@@ -28,7 +28,7 @@ impl Default for MdFormatConfig {
     fn default() -> Self {
         Self {
             system: "# {{name}}".to_owned(),
-            area: "## {{full_id id}}.{{start id_range}}-{{end id_range}} {{topic}}".to_owned(),
+            area: "## {{full_id id}} {{topic}}".to_owned(),
             category: "- {{full_id id}} {{topic}}".to_owned(),
             folder: "  - {{#if (is_folder kind)}}{{full_id id}} {{topic}}{{else}}[[{{full_id id}} {{topic}}]]{{/if}}".to_owned(),
             xfolder: "    - {{#if (is_folder kind)}}{{full_id id}} {{topic}}{{else}}[[{{full_id id}} {{topic}}]]{{/if}}".to_owned(),


### PR DESCRIPTION
Without the `full_id` filter, the id just outputs as `[object]` instead of the parent id. Also because `full_id` properly encodes the range, we don't need the range in the template either