### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/graysonarts/jdexmd/compare/v0.1.3...v0.1.4) - 2024-09-30
+
+### Other
+
+- The area markdown template didn't pass in full Id to the id ([#12](https://github.com/graysonarts/jdexmd/pull/12))
+
 ## [0.1.3](https://github.com/graysonarts/jdexmd/compare/v0.1.2...v0.1.3) - 2024-09-29
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,7 +396,7 @@ checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jdexmd"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "cargo-husky",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jdexmd"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 repository = "https://github.com/graysonarts/jdexmd"
 description = "A tool to generate a Johnny Decimal system for Obsidian and your Documents folder."


### PR DESCRIPTION
## 🤖 New release
* `jdexmd`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/graysonarts/jdexmd/compare/v0.1.3...v0.1.4) - 2024-09-30

### Other

- The area markdown template didn't pass in full Id to the id ([#12](https://github.com/graysonarts/jdexmd/pull/12))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).